### PR TITLE
SRT bulk packets transfer for correct bandwidth estimation

### DIFF
--- a/Example/iOS Example/Source/ViewController.swift
+++ b/Example/iOS Example/Source/ViewController.swift
@@ -36,7 +36,7 @@ class ViewController: UIViewController {
                 UIView.animate(withDuration: 0.1, delay: 0.0,
                                options: [.curveEaseInOut, .repeat, .autoreverse, .allowUserInteraction],
                                animations: {() -> Void in
-                    self.btnConnect.alpha = 0.0
+                    self.btnConnect.alpha = 0.1
                 }, completion: {(_: Bool) -> Void in
                 })
             } else if connecting && !newValue {


### PR DESCRIPTION
SRT bandwidth estimation requires that sender transmit most packets bursty.
// https://github.com/Haivision/srt/blob/v1.3.1/srtcore/window.cpp#L201-L222

At low bitrate, transmission interval between packets become large, and it makes bandwidth estimation calculate wrongly at receiving side.

This fix store 10 packets in buffer and send them bursty.
srt-live-transmit also sends 10 packets at a time.
https://github.com/Haivision/srt/blob/v1.3.1/apps/srt-live-transmit.cpp#L556
